### PR TITLE
Fix user tests and add name column

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,9 +16,10 @@ class User {
     }
     
     public function create($data) {
-        $sql = "INSERT INTO users (email, password, role) VALUES (?, ?, ?)";
+        $sql = "INSERT INTO users (name, email, password, role) VALUES (?, ?, ?, ?)";
         $stmt = $this->db->prepare($sql);
         $stmt->execute([
+            $data['name'] ?? null,
             $data['email'],
             $data['password'],
             $data['role'] ?? 'user'

--- a/app/Utils/Security.php
+++ b/app/Utils/Security.php
@@ -423,6 +423,17 @@ class Security {
     }
 
     /**
+     * Verifies a plaintext password against a hash
+     *
+     * @param string $password Plain text password
+     * @param string $hash     Hashed password
+     * @return bool True if password matches the hash, false otherwise
+     */
+    public function verifyPassword($password, $hash) {
+        return password_verify($password, $hash);
+    }
+
+    /**
      * Generates a CSRF token for form protection
      * Creates a new token if one doesn't exist in the session
      * Uses cryptographically secure random bytes

--- a/tests/helpers/TestHelper.php
+++ b/tests/helpers/TestHelper.php
@@ -21,7 +21,7 @@ class TestHelper {
      */
     public static function createTestUser($overrides = []) {
         return array_merge([
-            'username' => 'testuser',
+            'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => 'Test123!',
             'role' => 'teacher'
@@ -66,6 +66,7 @@ class TestHelper {
         // Create users table
         $pdo->exec("CREATE TABLE IF NOT EXISTS users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
             email TEXT NOT NULL UNIQUE,
             password TEXT NOT NULL,
             role TEXT DEFAULT 'user',


### PR DESCRIPTION
## Summary
- support storing user `name`
- expose `Security::verifyPassword`
- update helper & tests for the new `name` field
- validate password using `Security` utility

## Testing
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd3038308330aa05afaecf9dbc04