### PR TITLE
Fix env setup text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@
 
 ## Configuration
 
-The application uses environment variables for configuration. Copy the `.env.example` file to `.env` and update the values:
+The application uses environment variables for configuration.
+Copy the `.env.example` file to `.env` and update the values:
 
 ```bash
 cp .env.example .env


### PR DESCRIPTION
## Summary
- update configuration instructions so `.env.example` isn't split across lines

## Testing
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd279df48330a6dc87691d16c519