### PR TITLE
Update user name handling

### DIFF
--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -173,6 +173,7 @@ class AuthController {
             }
 
             // Sanitize and validate input
+            $name = SecurityHelper::sanitizeInput($_POST['name'] ?? '');
             $email = SecurityHelper::sanitizeInput($_POST['email'] ?? '');
             $password = $_POST['password'] ?? '';
             $confirmPassword = $_POST['confirm_password'] ?? '';
@@ -216,6 +217,7 @@ class AuthController {
             
             // Create new user with hashed password
             $userId = $this->userModel->create([
+                'name' => $name,
                 'email' => $email,
                 'password' => password_hash($password, PASSWORD_DEFAULT),
                 'role' => 'user'

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,9 +16,10 @@ class User {
     }
     
     public function create($data) {
-        $sql = "INSERT INTO users (email, password, role) VALUES (?, ?, ?)";
+        $sql = "INSERT INTO users (name, email, password, role) VALUES (?, ?, ?, ?)";
         $stmt = $this->db->prepare($sql);
         $stmt->execute([
+            $data['name'],
             $data['email'],
             $data['password'],
             $data['role'] ?? 'user'

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -15,7 +15,7 @@ class UserTest extends TestCase {
         // Create users table
         $this->pdo->exec("CREATE TABLE users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            username TEXT NOT NULL,
+            name TEXT NOT NULL,
             email TEXT NOT NULL,
             password TEXT NOT NULL,
             role TEXT NOT NULL,
@@ -39,7 +39,7 @@ class UserTest extends TestCase {
         
         $this->assertIsArray($foundUser);
         $this->assertEquals($userData['email'], $foundUser['email']);
-        $this->assertEquals($userData['username'], $foundUser['username']);
+        $this->assertEquals($userData['name'], $foundUser['name']);
     }
 
     public function testValidatePassword() {

--- a/tests/helpers/TestHelper.php
+++ b/tests/helpers/TestHelper.php
@@ -21,7 +21,7 @@ class TestHelper {
      */
     public static function createTestUser($overrides = []) {
         return array_merge([
-            'username' => 'testuser',
+            'name' => 'testuser',
             'email' => 'test@example.com',
             'password' => 'Test123!',
             'role' => 'teacher'


### PR DESCRIPTION
## Summary
- store name in `users` table via `User::create`
- supply name when registering new users
- adjust user test helpers and schema

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd1f3aa883308a3264c335f9f364